### PR TITLE
Add draft field to PR and body_html to Release

### DIFF
--- a/library/src/main/java/com/meisolsson/githubsdk/model/PullRequest.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/PullRequest.java
@@ -94,6 +94,9 @@ public abstract class PullRequest implements Parcelable {
     public abstract MergeableState mergeableState();
 
     @Nullable
+    public abstract Boolean draft();
+
+    @Nullable
     public abstract IssueState state();
 
     @Nullable
@@ -217,6 +220,8 @@ public abstract class PullRequest implements Parcelable {
         public abstract Builder merged(Boolean merged);
 
         public abstract Builder mergeableState(MergeableState mergeableState);
+
+        public abstract Builder draft(Boolean draft);
 
         public abstract Builder state(IssueState state);
 

--- a/library/src/main/java/com/meisolsson/githubsdk/model/Release.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/Release.java
@@ -20,6 +20,7 @@ import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.meisolsson.githubsdk.core.FormattedHtml;
 import com.meisolsson.githubsdk.core.FormattedTime;
 import com.google.auto.value.AutoValue;
 import com.squareup.moshi.Json;
@@ -40,6 +41,11 @@ public abstract class Release implements Parcelable {
 
     @Nullable
     public abstract String body();
+
+    @Nullable
+    @Json(name = "body_html")
+    @FormattedHtml
+    public abstract String bodyHtml();
 
     @Nullable
     public abstract Long id();


### PR DESCRIPTION
I've added two fields to the bindings that will be useful for a couple of improvements I want to make to the app:
- `draft` field to PullRequest, in order to be able to tell whether a PR is a draft (and update the UI accordingly)
- `bodyHtml` to Release, in order to avoid a call to the Markdown API to format the body of a release

It would be awesome if you could release a new version of the library after this is merged.

PS: is this the correct branch? :D