### PR TITLE
Increase robustness in case of unknown enum values

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation 'com.squareup.retrofit2:adapter-rxjava2:2.5.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.6.0'
     implementation 'com.squareup.moshi:moshi:1.8.0'
+    implementation 'com.squareup.moshi:moshi-adapters:1.8.0'
 
     compileOnly 'com.ryanharter.auto.value:auto-value-moshi-annotations:0.4.7'
     annotationProcessor 'com.ryanharter.auto.value:auto-value-moshi:0.4.7'

--- a/library/src/main/java/com/meisolsson/githubsdk/core/ServiceGenerator.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/core/ServiceGenerator.java
@@ -19,9 +19,13 @@ package com.meisolsson.githubsdk.core;
 import android.content.Context;
 import android.text.TextUtils;
 
+import com.meisolsson.githubsdk.model.IssueEventType;
+import com.meisolsson.githubsdk.model.NotificationReason;
 import com.meisolsson.githubsdk.model.ReviewState;
 import com.meisolsson.githubsdk.service.OAuthService;
 import com.squareup.moshi.Moshi;
+import com.squareup.moshi.adapters.EnumJsonAdapter;
+
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -39,6 +43,8 @@ public class ServiceGenerator {
             .add(new GitHubEventAdapter())
             .add(new GitHubPayloadAdapter())
             .add(ReviewState.class, new CaseInsensitiveEnumJsonAdapter(ReviewState.class))
+            .add(IssueEventType.class, EnumJsonAdapter.create(IssueEventType.class).withUnknownFallback(null))
+            .add(NotificationReason.class, EnumJsonAdapter.create(NotificationReason.class).withUnknownFallback(null))
             .add(MyAdapterFactory.create())
             .add(new FormattedHtmlAdapter())
             .add(new FormattedTimeAdapter())

--- a/library/src/main/java/com/meisolsson/githubsdk/model/NotificationReason.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/NotificationReason.java
@@ -30,5 +30,9 @@ public enum NotificationReason {
     @Json(name = "security_alert") SecurityAlert,
     @Json(name = "assign") Assign,
     @Json(name = "ci_activity") CiActivity,
-    @Json(name = "") Unset // sent when updating subscriptions
+    @Json(name = "") Unset, // sent when updating subscriptions
+    @Json(name = "invitation") Invitation,
+    @Json(name = "push") Push,
+    @Json(name = "your_activity") YourActivity,
+    @Json(name = "approval_requested") ApprovalRequested
 }


### PR DESCRIPTION
In this PR, I've added some missing values for `NotificationReason` enum taken from [here](https://docs.github.com/en/rest/reference/activity#notifications), [here](https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications#filtering-email-notifications) and slapperwan/gh4a#1117.

But more importantly, I have implemented a solution that prevents the app from crashing when the API returns unknown values for `IssueEventType` and `NotificationReason` enums using Moshi's [EnumJsonAdapter](https://square.github.io/moshi/1.x/moshi-adapters/adapters/com.squareup.moshi.adapters/-enum-json-adapter/index.html).
For now only those two enums are "fault-tolerant", we can always add more later if we want to.