### PR TITLE
Add some API calls for retrieving repository contents & more

### DIFF
--- a/library/src/main/java/com/meisolsson/githubsdk/model/ReviewComment.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/ReviewComment.java
@@ -43,6 +43,10 @@ public abstract class ReviewComment extends PositionalCommentBase {
     @Nullable
     public abstract Integer pullRequestReviewId();
 
+    @Json(name = "in_reply_to_id")
+    @Nullable
+    public abstract Integer inReplyToId();
+
     public abstract Builder toBuilder();
 
     @Json(name = "pull_request_url")
@@ -62,6 +66,8 @@ public abstract class ReviewComment extends PositionalCommentBase {
         public abstract Builder originalPosition(Integer originalPosition);
 
         public abstract Builder pullRequestReviewId(Integer pullRequestReviewId);
+
+        public abstract Builder inReplyToId(Integer inReplyToId);
 
         public abstract Builder pullRequestUrl(String pullRequestUrl);
 

--- a/library/src/main/java/com/meisolsson/githubsdk/service/repositories/RepositoryContentService.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/service/repositories/RepositoryContentService.java
@@ -37,15 +37,24 @@ import retrofit2.http.Query;
 public interface RepositoryContentService {
 
     @GET("repos/{owner}/{repo}/readme")
-    @Headers("Accept: application/vnd.github.html")
+    @Headers("Accept: application/vnd.github.v3.html")
     Single<Response<String>> getReadmeHtml(@Path("owner") String owner, @Path("repo") String repo, @Query("ref") String ref);
 
     @GET("repos/{owner}/{repo}/readme")
-    @Headers("Accept: application/vnd.github.VERSION.raw")
+    @Headers("Accept: application/vnd.github.v3.raw")
     Single<Response<String>> getReadmeRaw(@Path("owner") String owner, @Path("repo") String repo, @Query("ref") String ref);
 
     @GET("repos/{owner}/{repo}/contents/{path}")
+    @Headers("Accept: application/vnd.github.v3+json")
     Single<Response<Content>> getContents(@Path("owner") String owner, @Path("repo") String repo, @Path("path") String path, @Query("ref") String ref);
+
+    @GET("repos/{owner}/{repo}/contents/{path}")
+    @Headers("Accept: application/vnd.github.v3.raw")
+    Single<Response<String>> getContentsRaw(@Path("owner") String owner, @Path("repo") String repo, @Path("path") String path, @Query("ref") String ref);
+
+    @GET("repos/{owner}/{repo}/contents/{path}")
+    @Headers("Accept: application/vnd.github.v3.html")
+    Single<Response<String>> getContentsHtml(@Path("owner") String owner, @Path("repo") String repo, @Path("path") String path, @Query("ref") String ref);
 
     @GET("repos/{owner}/{repo}/contents/{path}")
     Single<Response<Page<Content>>> getDirectoryContents(@Path("owner") String owner, @Path("repo") String repo, @Path("path") String path, @Query("ref") String ref, @Query("page") long page);


### PR DESCRIPTION
This PR adds two useful features to the bindings:
- API calls to retrieve raw (`getContentsRaw`) and HTML-rendered (`getContentsHtml`) file contents.
I plan to use the former to optimize retrieving files in OctoDroid, since the "standard" `getContents` call returns Base64-encoded contents of the file which are ~50% bigger than raw ones.
`getContentsHtml()` may be used in the future to replace Showdown.js for displaying Markdown files, in order to make rendering more faithful to the GitHub website.
- `in_reply_to_id` field to review comments. I discovered it some weeks ago while doing some research, it may be useful in case someone wants to refine the logic used to group review comments in threads (which is currently imperfect).