### PR TITLE
Add previous_filename field to GitHubFile

### DIFF
--- a/library/src/main/java/com/meisolsson/githubsdk/model/GitHubFile.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/GitHubFile.java
@@ -30,6 +30,10 @@ public abstract class GitHubFile implements Parcelable {
     @Nullable
     public abstract String filename();
 
+    @Json(name = "previous_filename")
+    @Nullable
+    public abstract String previousFilename();
+
     @Nullable
     public abstract String status();
 
@@ -69,6 +73,8 @@ public abstract class GitHubFile implements Parcelable {
     @AutoValue.Builder
     public abstract static class Builder {
         public abstract Builder filename(String filename);
+
+        public abstract Builder previousFilename(String previousFilename);
 
         public abstract Builder status(String status);
 


### PR DESCRIPTION
This allows to retrieve the previous filename of a file that was renamed in a commit.
See https://api.github.com/repos/topjohnwu/Magisk/commits/b4120cddfbc92549094e4dbe76ed4fd1b41c0293 for an example