### PR TITLE
Add some more possible FieldError reasons

### DIFF
--- a/library/src/main/java/com/meisolsson/githubsdk/model/ClientErrorResponse.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/ClientErrorResponse.java
@@ -58,6 +58,8 @@ public abstract class ClientErrorResponse implements Parcelable {
             @Json(name = "invalid") Invalid,
             @Json(name = "already_exists") AlreadyExists,
             @Json(name = "too_large") TooLarge,
+            @Json(name = "not_available") NotAvailable,
+            @Json(name = "unprocessable") Unprocessable,
             @Json(name = "custom") Custom
         }
 


### PR DESCRIPTION
This PR adds two more values to FieldError Reason enum.
`not_available` can be observed while calling https://api.github.com/repos/github/rest-api-description/compare/v1.1.3...v1.1.4, while `unprocessable` is [listed in GitHub docs](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#client-errors) but was not present in the enum.