### PR TITLE
Add `waiting` status to CheckRunState

### DIFF
--- a/library/src/main/java/com/meisolsson/githubsdk/model/CheckRunState.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/CheckRunState.java
@@ -22,5 +22,6 @@ public enum CheckRunState {
     @Json(name = "completed") Completed,
     @Json(name = "in_progress") InProgress,
     @Json(name = "queued") Queued,
-    @Json(name = "requested") Requested
+    @Json(name = "requested") Requested,
+    @Json(name = "waiting") Waiting
 }


### PR DESCRIPTION
Needed to fix slapperwan/gh4a#1169.
~~I suspect this may be the status in which the message "Waiting for status to be reported" is being displayed for a check run.~~