### PR TITLE
Fix rocket and eyes reactions not being counted in totalCount

### DIFF
--- a/library/src/main/java/com/meisolsson/githubsdk/model/Reactions.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/Reactions.java
@@ -30,7 +30,7 @@ import java.util.Date;
 @AutoValue
 public abstract class Reactions implements Parcelable {
     public int totalCount() {
-        return plusOne() + minusOne() + laugh() + hooray() + confused() + heart();
+        return plusOne() + minusOne() + laugh() + hooray() + confused() + heart() + rocket() + eyes();
     }
 
     @Json(name = "+1")


### PR DESCRIPTION
This was causing reactions not to be displayed when a comment had only rocket or eyes reactions.

Sorry for asking you to make another release :sweat_smile:
This should be the last one (for some time at least)