### PR TITLE
Change getContentsRaw return type to byte array

### DIFF
--- a/library/src/main/java/com/meisolsson/githubsdk/service/repositories/RepositoryContentService.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/service/repositories/RepositoryContentService.java
@@ -50,7 +50,7 @@ public interface RepositoryContentService {
 
     @GET("repos/{owner}/{repo}/contents/{path}")
     @Headers("Accept: application/vnd.github.v3.raw")
-    Single<Response<String>> getContentsRaw(@Path("owner") String owner, @Path("repo") String repo, @Path("path") String path, @Query("ref") String ref);
+    Single<Response<byte[]>> getContentsRaw(@Path("owner") String owner, @Path("repo") String repo, @Path("path") String path, @Query("ref") String ref);
 
     @GET("repos/{owner}/{repo}/contents/{path}")
     @Headers("Accept: application/vnd.github.v3.html")


### PR DESCRIPTION
In #3 I forgot that GitHub repos can contain binary files too, which obviously shouldn't be returned as strings.