### PR TITLE
Remove `<p>` replacement in HTML bodies + some fields/API additions

### DIFF
--- a/library/src/main/java/com/meisolsson/githubsdk/core/HtmlUtils.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/core/HtmlUtils.java
@@ -49,10 +49,6 @@ public class HtmlUtils {
 
     private static final String BREAK = "<br>";
 
-    private static final String PARAGRAPH_START = "<p>";
-
-    private static final String PARAGRAPH_END = "</p>";
-
     private static final String BLOCKQUOTE_START = "<blockquote>";
 
     private static final String BLOCKQUOTE_END = "</blockquote>";
@@ -73,7 +69,7 @@ public class HtmlUtils {
      * @param html
      * @return formatted HTML
      */
-    public static final CharSequence format(final String html) {
+    public static CharSequence format(final String html) {
         if (html == null)
             return "";
         if (html.length() == 0)
@@ -93,10 +89,6 @@ public class HtmlUtils {
 
         // Remove hidden div
         strip(formatted, HIDDEN_REPLY_START, HIDDEN_REPLY_END);
-
-        // Replace paragraphs with breaks
-        if (replace(formatted, PARAGRAPH_START, BREAK))
-            replace(formatted, PARAGRAPH_END, BREAK);
 
         formatPres(formatted);
 
@@ -121,21 +113,6 @@ public class HtmlUtils {
             start = input.indexOf(prefix, start);
         }
         return input;
-    }
-
-    private static boolean replace(final StringBuilder input,
-                                   final String from, final String to) {
-        int start = input.indexOf(from);
-        if (start == -1)
-            return false;
-
-        final int fromLength = from.length();
-        final int toLength = to.length();
-        while (start != -1) {
-            input.replace(start, start + fromLength, to);
-            start = input.indexOf(from, start + toLength);
-        }
-        return true;
     }
 
     private static StringBuilder replace(final StringBuilder input,

--- a/library/src/main/java/com/meisolsson/githubsdk/core/ServiceGenerator.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/core/ServiceGenerator.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.text.TextUtils;
 
 import com.meisolsson.githubsdk.model.IssueEventType;
+import com.meisolsson.githubsdk.model.IssueStateReason;
 import com.meisolsson.githubsdk.model.NotificationReason;
 import com.meisolsson.githubsdk.model.ReviewState;
 import com.meisolsson.githubsdk.service.OAuthService;
@@ -45,6 +46,7 @@ public class ServiceGenerator {
             .add(ReviewState.class, new CaseInsensitiveEnumJsonAdapter(ReviewState.class))
             .add(IssueEventType.class, EnumJsonAdapter.create(IssueEventType.class).withUnknownFallback(null))
             .add(NotificationReason.class, EnumJsonAdapter.create(NotificationReason.class).withUnknownFallback(null))
+            .add(IssueStateReason.class, EnumJsonAdapter.create(IssueStateReason.class).withUnknownFallback(null))
             .add(MyAdapterFactory.create())
             .add(new FormattedHtmlAdapter())
             .add(new FormattedTimeAdapter())

--- a/library/src/main/java/com/meisolsson/githubsdk/model/Issue.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/Issue.java
@@ -60,7 +60,14 @@ public abstract class Issue implements Parcelable {
     public abstract Boolean locked();
 
     @Nullable
+    public abstract Boolean draft();
+
+    @Nullable
     public abstract IssueState state();
+
+    @Json(name = "state_reason")
+    @Nullable
+    public abstract IssueStateReason stateReason();
 
     @Nullable
     public abstract User user();
@@ -142,7 +149,11 @@ public abstract class Issue implements Parcelable {
 
         public abstract Builder locked(Boolean locked);
 
+        public abstract Builder draft(Boolean draft);
+
         public abstract Builder state(IssueState state);
+
+        public abstract Builder stateReason(IssueStateReason stateReason);
 
         public abstract Builder user(User user);
 

--- a/library/src/main/java/com/meisolsson/githubsdk/model/IssueEvent.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/IssueEvent.java
@@ -108,8 +108,15 @@ public abstract class IssueEvent implements Parcelable {
     @Nullable
     public abstract DismissedReview dismissedReview();
 
-    // TODO: All of the below belong to the timeline API and need to be re-checked
-    //       once that API is out of preview.
+    @Json(name = "lock_reason")
+    @Nullable
+    public abstract String lockReason();
+
+    @Json(name = "state_reason")
+    @Nullable
+    public abstract IssueStateReason stateReason();
+
+    // All of the below belong to the timeline API
 
     public enum ReviewEventState {
         @Json(name = "approved") Approved,

--- a/library/src/main/java/com/meisolsson/githubsdk/model/IssueEventType.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/IssueEventType.java
@@ -38,8 +38,6 @@ public enum IssueEventType {
     @Json(name = "convert_to_draft") ConvertToDraft,
     @Json(name = "converted_note_to_issue") ConvertedNoteToIssue,
     @Json(name = "converted_to_discussion") ConvertedToDiscussion,
-    /*TODO Is this working correctly? This is used by the issue timeline api which is not
-        yet stable. When it' stable this needs to be tested*/
     @Json(name = "cross-referenced") CrossReferenced,
     @Json(name = "demilestoned") Demilestoned,
     @Json(name = "deployed") Deployed,

--- a/library/src/main/java/com/meisolsson/githubsdk/model/IssueStateReason.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/IssueStateReason.java
@@ -1,0 +1,9 @@
+package com.meisolsson.githubsdk.model;
+
+import com.squareup.moshi.Json;
+
+public enum IssueStateReason {
+    @Json(name = "reopened") Reopened,
+    @Json(name = "completed") Completed,
+    @Json(name = "not_planned") NotPlanned
+}

--- a/library/src/main/java/com/meisolsson/githubsdk/model/PullRequest.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/PullRequest.java
@@ -109,6 +109,10 @@ public abstract class PullRequest implements Parcelable {
     @Nullable
     public abstract List<User> requestedReviewers();
 
+    @Json(name = "requested_teams")
+    @Nullable
+    public abstract List<Team> requestedTeams();
+
     @Json(name = "maintainer_can_modify")
     @Nullable
     public abstract Boolean isModifiableByMaintainer();
@@ -230,6 +234,8 @@ public abstract class PullRequest implements Parcelable {
         public abstract Builder assignee(User assignee);
 
         public abstract Builder requestedReviewers(List<User> reviewers);
+
+        public abstract Builder requestedTeams(List<Team> teamReviewers);
 
         public abstract Builder isModifiableByMaintainer(Boolean modifiable);
 

--- a/library/src/main/java/com/meisolsson/githubsdk/model/Release.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/Release.java
@@ -90,6 +90,9 @@ public abstract class Release implements Parcelable {
     @Nullable
     public abstract String targetCommitish();
 
+    @Nullable
+    public abstract Reactions reactions();
+
     @Json(name = "created_at")
     @Nullable
     @FormattedTime

--- a/library/src/main/java/com/meisolsson/githubsdk/model/Repository.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/Repository.java
@@ -26,6 +26,7 @@ import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 
 import java.util.Date;
+import java.util.List;
 
 @AutoValue
 public abstract class Repository implements Parcelable {
@@ -77,6 +78,9 @@ public abstract class Repository implements Parcelable {
 
     @Nullable
     public abstract Permissions permissions();
+
+    @Nullable
+    public abstract List<String> topics();
 
     @Json(name = "full_name")
     @Nullable
@@ -191,6 +195,8 @@ public abstract class Repository implements Parcelable {
         public abstract Builder source(Repository source);
 
         public abstract Builder permissions(Permissions permissions);
+
+        public abstract Builder topics(List<String> topics);
 
         public abstract Builder fullName(String fullName);
 

--- a/library/src/main/java/com/meisolsson/githubsdk/model/Repository.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/Repository.java
@@ -59,6 +59,10 @@ public abstract class Repository implements Parcelable {
     @Nullable
     public abstract Boolean isArchived();
 
+    @Json(name = "is_template")
+    @Nullable
+    public abstract Boolean isTemplate();
+
     @Nullable
     public abstract User owner();
 
@@ -175,6 +179,8 @@ public abstract class Repository implements Parcelable {
         public abstract Builder isFork(Boolean newFork);
 
         public abstract Builder isArchived(Boolean archived);
+
+        public abstract Builder isTemplate(Boolean isTemplate);
 
         public abstract Builder owner(User owner);
 

--- a/library/src/main/java/com/meisolsson/githubsdk/service/reactions/ReactionService.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/service/reactions/ReactionService.java
@@ -66,4 +66,13 @@ public interface ReactionService {
 
     @DELETE("repos/{owner}/{repo}/pulls/comments/{comment}/reactions/{id}")
     Single<Response<Void>> deletePullRequestReviewCommentReaction(@Path("owner") String owner, @Path("repo") String repo, @Path("comment") long commentId, @Path("id") long reactionId);
+
+    @GET("repos/{owner}/{repo}/releases/{release_id}/reactions")
+    Single<Response<Page<Reaction>>> getReleaseReactions(@Path("owner") String owner, @Path("repo") String repo, @Path("release_id") long releaseId, @Query("page") long page);
+
+    @POST("repos/{owner}/{repo}/releases/{release_id}/reactions")
+    Single<Response<Reaction>> createReleaseReaction(@Path("owner") String owner, @Path("repo") String repo, @Path("release_id") long releaseId, @Body ReactionRequest request);
+
+    @DELETE("repos/{owner}/{repo}/releases/{release_id}/reactions/{id}")
+    Single<Response<Void>> deleteReleaseReaction(@Path("owner") String owner, @Path("repo") String repo, @Path("release_id") long releaseId, @Path("id") long reactionId);
 }


### PR DESCRIPTION
I've made an interesting discovery while chasing a smallish Markdown rendering bug that affects the body of [this release](https://github.com/TeamNewPipe/NewPipe/releases/tag/v0.23.1):

![rel_note_bug](https://user-images.githubusercontent.com/30041551/181062031-bad95c12-8e27-4cf5-9bf4-e882be500c72.png)

Notice the newline after the bullet? I wasn't able to reproduce this bug at all, I even tried to paste the HTML body of the release as-is in a test issue but the rendering was still correct. It was simply a `<p>` inside a `<li>`...
Then, while stepping with the debugger, I saw that the HTML body had already been transformed before reaching the `HtmlToSpannedConverter`, and that `<p>`s had been replaced with `<br>`s. The culprit was then quickly found...

This PR removes the code responsible for this `<p>` -> `<br>` substitution since it's useless: our parser already handles `<p>` tags well and, interestingly, the substitution hardly ever kicks in, because GitHub always adds the `dir="auto"` attribute to `<p>`s (which is the reason I wasn't able to reproduce the issue). For some reason, in the release body the `<p>`s were left without the `dir` attribute and therefore were caught by the substitution logic.

---

I've also added a few interesting fields/APIs that could be displayed/used in the app, most notably:
- reactions API and field for releases
- `state_reason` field for Issue and timeline events (see https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/)
- the `draft` field for Issue: it's present only when the Issue is a pull request and can be used to display whether a PR is a draft in the PRs list

You can publish a new release of the binding after merging this *(though I'd really like to see the bindings as a separate module in the app repo, I was surprised to see this logic that really belongs to the application in an external library)*.