### PR TITLE
Add `dismissal_commit_id` and add some missing enum values

### DIFF
--- a/library/src/main/java/com/meisolsson/githubsdk/core/ServiceGenerator.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/core/ServiceGenerator.java
@@ -23,6 +23,7 @@ import com.meisolsson.githubsdk.model.IssueEventType;
 import com.meisolsson.githubsdk.model.IssueStateReason;
 import com.meisolsson.githubsdk.model.NotificationReason;
 import com.meisolsson.githubsdk.model.ReviewState;
+import com.meisolsson.githubsdk.model.VerificationResult;
 import com.meisolsson.githubsdk.service.OAuthService;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.adapters.EnumJsonAdapter;
@@ -47,6 +48,7 @@ public class ServiceGenerator {
             .add(IssueEventType.class, EnumJsonAdapter.create(IssueEventType.class).withUnknownFallback(null))
             .add(NotificationReason.class, EnumJsonAdapter.create(NotificationReason.class).withUnknownFallback(null))
             .add(IssueStateReason.class, EnumJsonAdapter.create(IssueStateReason.class).withUnknownFallback(null))
+            .add(VerificationResult.Reason.class, EnumJsonAdapter.create(VerificationResult.Reason.class).withUnknownFallback(null))
             .add(MyAdapterFactory.create())
             .add(new FormattedHtmlAdapter())
             .add(new FormattedTimeAdapter())

--- a/library/src/main/java/com/meisolsson/githubsdk/model/IssueEvent.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/IssueEvent.java
@@ -43,6 +43,10 @@ public abstract class IssueEvent implements Parcelable {
         @Nullable
         public abstract String dismissalMessage();
 
+        @Json(name = "dismissal_commit_id")
+        @Nullable
+        public abstract String dismissalCommitId();
+
         public static JsonAdapter<DismissedReview> jsonAdapter(Moshi moshi) {
             return new AutoValue_IssueEvent_DismissedReview.MoshiJsonAdapter(moshi);
         }

--- a/library/src/main/java/com/meisolsson/githubsdk/model/UserType.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/UserType.java
@@ -19,5 +19,6 @@ package com.meisolsson.githubsdk.model;
 public enum UserType {
     User,
     Organization,
-    Bot
+    Bot,
+    Mannequin
 }

--- a/library/src/main/java/com/meisolsson/githubsdk/model/VerificationResult.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/VerificationResult.java
@@ -27,6 +27,7 @@ import com.squareup.moshi.Moshi;
 @AutoValue
 public abstract class VerificationResult implements Parcelable {
     public enum Reason {
+        @Json(name = "bad_cert") BadCertificate,
         @Json(name = "bad_email") BadEmail,
         @Json(name = "expired_key") ExpiredKey,
         @Json(name = "gpgverify_error") GpgVerifyError,


### PR DESCRIPTION
Today I've tried to add support for the `review_dismissed` timeline event in the app, but I've noticed that the `dismissal_commit_id` field of that event was missing (which is needed to be able to display "X dismissed a stale review via **_[commit_id]_**").

While I was at it, I've added a few missing enum values that were causing errors in the app (reported in https://github.com/slapperwan/gh4a/issues/1235, https://github.com/slapperwan/gh4a/issues/1238 and https://github.com/slapperwan/gh4a/issues/1226).
Mannequin users should also be handled properly in the app ([here](https://discuss.python.org/t/github-issues-migration-mannequin-users/14965) you can find some info on what they are, they don't seem to be officially documented).