### PR TITLE
Update dependencies and Gradle/AGP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath 'com.novoda:bintray-release:0.9.1'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -18,11 +18,12 @@ apply plugin: "com.android.library"
 //apply plugin: 'bintray-release'
 
 android {
-    compileSdkVersion 30
+    namespace "com.meisolsson.githubsdk"
+    compileSdk 30
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 30
+        minSdk 15
+        targetSdk 30
         versionCode VERSION_CODE
         versionName VERSION_NAME
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -40,14 +40,14 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
     api 'io.reactivex.rxjava2:rxjava:2.2.21'
-    api 'com.squareup.retrofit2:retrofit:2.6.4'
+    api 'com.squareup.retrofit2:retrofit:2.9.0'
 
-    implementation 'androidx.annotation:annotation:1.3.0'
-    implementation 'com.squareup.retrofit2:converter-moshi:2.6.4'
-    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.6.4'
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.12.13'
-    implementation 'com.squareup.moshi:moshi:1.12.0'
-    implementation 'com.squareup.moshi:moshi-adapters:1.12.0'
+    implementation 'androidx.annotation:annotation:1.6.0'
+    implementation 'com.squareup.retrofit2:converter-moshi:2.9.0'
+    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.9.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.14.9'
+    implementation 'com.squareup.moshi:moshi:1.15.0'
+    implementation 'com.squareup.moshi:moshi-adapters:1.15.0'
 
     annotationProcessor "com.ryanharter.auto.value:auto-value-moshi-extension:1.1.0"
     implementation "com.ryanharter.auto.value:auto-value-moshi-runtime:1.1.0"
@@ -59,8 +59,8 @@ dependencies {
     implementation 'com.ryanharter.auto.value:auto-value-parcel-adapter:0.2.9'
     annotationProcessor 'com.ryanharter.auto.value:auto-value-parcel:0.2.9'
 
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 /*

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -19,10 +19,10 @@ apply plugin: "com.android.library"
 
 android {
     namespace "com.meisolsson.githubsdk"
-    compileSdk 30
+    compileSdk 33
 
     defaultConfig {
-        minSdk 15
+        minSdk 21
         targetSdk 30
         versionCode VERSION_CODE
         versionName VERSION_NAME

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.meisolsson.githubsdk"
-          xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application android:allowBackup="true"
                  android:label="@string/app_name"


### PR DESCRIPTION
Since the app's minSdk is now bumped to 21, we can bump it here too so that we can update OkHttp and Retrofit.
I haven't bumped AutoValue because it seems that auto-value-parcel hasn't been updated to support the latest version yet.

I have also updated AGP and Gradle and fixed some minor deprecation warnings. I chose not to update to Gradle 8 because the build appears to use some features that are incompatible with the latest version.