### PR TITLE
Add some miscellaneous missing fields

### DIFF
--- a/library/src/main/java/com/meisolsson/githubsdk/model/Repository.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/Repository.java
@@ -134,6 +134,14 @@ public abstract class Repository implements Parcelable {
     @Nullable
     public abstract Boolean hasDownloads();
 
+    @Json(name = "has_discussions")
+    @Nullable
+    public abstract Boolean hasDiscussions();
+
+    @Json(name = "has_projects")
+    @Nullable
+    public abstract Boolean hasProjects();
+
     @Json(name = "pushed_at")
     @Nullable
     @FormattedTime
@@ -223,6 +231,10 @@ public abstract class Repository implements Parcelable {
         public abstract Builder hasPages(Boolean hasPages);
 
         public abstract Builder hasDownloads(Boolean hasDownloads);
+
+        public abstract Builder hasDiscussions(Boolean hasDiscussions);
+
+        public abstract Builder hasProjects(Boolean hasProjects);
 
         public abstract Builder pushedAt(Date pushedAt);
 

--- a/library/src/main/java/com/meisolsson/githubsdk/model/ReviewComment.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/ReviewComment.java
@@ -31,6 +31,10 @@ public abstract class ReviewComment extends PositionalCommentBase {
     @Nullable
     public abstract String diffChunk();
 
+    @Json(name = "subject_type")
+    @Nullable
+    public abstract ReviewCommentSubjectType subjectType();
+
     @Json(name = "original_commit_id")
     @Nullable
     public abstract String originalCommitId();
@@ -60,6 +64,8 @@ public abstract class ReviewComment extends PositionalCommentBase {
     @AutoValue.Builder
     public abstract static class Builder extends PositionalCommentBase.Builder<Builder> {
         public abstract Builder diffChunk(String diffChunk);
+
+        public abstract Builder subjectType(ReviewCommentSubjectType subjectType);
 
         public abstract Builder originalCommitId(String originalCommitId);
 

--- a/library/src/main/java/com/meisolsson/githubsdk/model/ReviewCommentSubjectType.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/ReviewCommentSubjectType.java
@@ -1,0 +1,8 @@
+package com.meisolsson.githubsdk.model;
+
+import com.squareup.moshi.Json;
+
+public enum ReviewCommentSubjectType {
+    @Json(name = "file") File,
+    @Json(name = "line") Line
+}

--- a/library/src/main/java/com/meisolsson/githubsdk/model/SearchPage.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/SearchPage.java
@@ -44,7 +44,7 @@ public abstract class SearchPage<V> {
 
     @Json(name = "total_count")
     @Nullable
-    public abstract Integer totalCount();
+    public abstract Long totalCount();
 
     @Json(name = "incomplete_results")
     @Nullable

--- a/library/src/main/java/com/meisolsson/githubsdk/model/request/issue/IssueRequest.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/request/issue/IssueRequest.java
@@ -21,6 +21,8 @@ import androidx.annotation.Nullable;
 
 import com.meisolsson.githubsdk.model.IssueState;
 import com.google.auto.value.AutoValue;
+import com.meisolsson.githubsdk.model.IssueStateReason;
+import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 
@@ -31,6 +33,10 @@ public abstract class IssueRequest implements Parcelable {
 
     @Nullable
     public abstract IssueState state();
+
+    @Json(name = "state_reason")
+    @Nullable
+    public abstract IssueStateReason stateReason();
 
     @Nullable
     public abstract String title();
@@ -58,6 +64,8 @@ public abstract class IssueRequest implements Parcelable {
     @AutoValue.Builder
     public abstract static class Builder {
         public abstract Builder state(IssueState state);
+
+        public abstract Builder stateReason(IssueStateReason stateReason);
 
         public abstract Builder title(String title);
 

--- a/library/src/main/java/com/meisolsson/githubsdk/model/request/pull_request/CreateReviewComment.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/request/pull_request/CreateReviewComment.java
@@ -21,6 +21,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
+import com.meisolsson.githubsdk.model.ReviewCommentSubjectType;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
@@ -45,6 +46,10 @@ public abstract class CreateReviewComment implements Parcelable {
     @Nullable
     public abstract Long inReplyTo();
 
+    @Json(name = "subject_type")
+    @Nullable
+    public abstract ReviewCommentSubjectType subjectType();
+
     public static JsonAdapter<CreateReviewComment> jsonAdapter(Moshi moshi) {
         return new AutoValue_CreateReviewComment.MoshiJsonAdapter(moshi);
     }
@@ -65,6 +70,8 @@ public abstract class CreateReviewComment implements Parcelable {
         public abstract Builder position(@Nullable Integer position);
 
         public abstract Builder inReplyTo(@Nullable Long inReplyTo);
+
+        public abstract Builder subjectType(ReviewCommentSubjectType subjectType);
 
         public abstract CreateReviewComment build();
     }


### PR DESCRIPTION
This PR adds the following missing fields:
- `has_discussions`/`has_projects` to repositories
- `status_reason` to IssueRequest, to allow specifying a reason when closing an issue
- `subject_type` to review comments, to be able to determine when a review comment was added to a specific line or to the whole file (see [this GH changelog post](https://github.blog/changelog/2023-04-11-commenting-on-files-in-a-pull-request-is-now-generally-available/) for more details)

I've also changed the type of SearchPage `total_count` field from int to long. This should likely fix slapperwan/gh4a#1277.

Once this is merged, feel free to release a new version of the library. Thanks!