### PR TITLE
Update dependencies

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -46,13 +46,13 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
     api 'io.reactivex.rxjava2:rxjava:2.2.21'
-    api 'com.squareup.retrofit2:retrofit:2.11.0'
+    api 'com.squareup.retrofit2:retrofit:3.0.0'
 
-    implementation 'androidx.annotation:annotation:1.8.2'
-    implementation 'com.squareup.retrofit2:converter-moshi:2.11.0'
-    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.11.0'
-    implementation 'com.squareup.moshi:moshi:1.15.1'
-    implementation 'com.squareup.moshi:moshi-adapters:1.15.1'
+    implementation 'androidx.annotation:annotation:1.9.1'
+    implementation 'com.squareup.retrofit2:converter-moshi:3.0.0'
+    implementation 'com.squareup.retrofit2:adapter-rxjava2:3.0.0'
+    implementation 'com.squareup.moshi:moshi:1.15.2'
+    implementation 'com.squareup.moshi:moshi-adapters:1.15.2'
 
     annotationProcessor "com.ryanharter.auto.value:auto-value-moshi-extension:1.1.0"
     implementation "com.ryanharter.auto.value:auto-value-moshi-runtime:1.1.0"


### PR DESCRIPTION
Only minor updates, no breaking changes. The only difference between Retrofit 2.12 and 3.0 is that the latter depends on OkHttp 4 instead of 3 (we are already depending on 4.x in the app, so no difference for us).